### PR TITLE
List all native gems, not just direct dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,8 @@ build/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
-# .ruby-version
-# .ruby-gemset
+Gemfile.lock
+.ruby-version
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc

--- a/exe/bundler-native-gems
+++ b/exe/bundler-native-gems
@@ -9,7 +9,7 @@ end
 
 require "bundler/setup"
 
-native_specs = Bundler.definition.dependencies.map(&:to_spec).reject {|spec| spec.extensions.empty? }
+native_specs = Bundler.definition.resolve.to_a.select { |spec| spec.__materialize__.extensions.any? }
 
 table = TTY::Table.new(
   header: ["Gem Name", "Version"],

--- a/exe/bundler-native-gems
+++ b/exe/bundler-native-gems
@@ -13,7 +13,7 @@ native_specs = Bundler.definition.resolve.to_a.select { |spec| spec.__materializ
 
 table = TTY::Table.new(
   header: ["Gem Name", "Version"],
-  rows: native_specs.map {|spec| [spec.name, spec.version] }
+  rows: native_specs.sort_by(&:name).map {|spec| [spec.name, spec.version] }
 )
 
 puts table.render(:ascii, padding: [0, 1, 0, 1])


### PR DESCRIPTION
`Definition#dependencies` just returns the top level dependencies listed in the Gemfile. What we actually want to do is resolve all the dependencies, then find any of _those_ that have extensions.

Fixes #2 
