### PR TITLE
Add the ability to list gems in specific groups

### DIFF
--- a/bundler-native-gems.gemspec
+++ b/bundler-native-gems.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.11"
-
+  spec.add_dependency "bundler", "~> 1.11"
   spec.add_dependency "tty", "~> 0.4.0"
 end

--- a/bundler-native-gems.gemspec
+++ b/bundler-native-gems.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "bundler", "~> 1.11"
-  spec.add_dependency "tty", "~> 0.4.0"
+  spec.add_dependency "terminal-table", "~> 1.5"
 end

--- a/exe/bundler-native-gems
+++ b/exe/bundler-native-gems
@@ -41,11 +41,22 @@ class NativeGems
 end
 
 class CLI < Bundler::CLI
+  def initialize(*)
+    super
+    # Replace `help` with Thor's version, not Bundler::CLI's
+    self.class.superclass.superclass.instance_method(:help).bind(self)
+  end
+
   desc "native_gems [OPTIONS]", "Lists the gems with native extensions"
   method_option "without", :type => :array, :banner => "Exclude gems that are part of the specified named group."
   method_option "with", :type => :array, :banner => "Include gems that are part of the specified named group."
+  method_option "help", :banner => "Print this help"
   def native_gems
-    NativeGems.new(options).run
+    if options[:help]
+      help("native_gems")
+    else
+      NativeGems.new(options).run
+    end
   end
 end
 

--- a/exe/bundler-native-gems
+++ b/exe/bundler-native-gems
@@ -1,19 +1,43 @@
 #!/usr/bin/env ruby
 
-begin
-require "tty"
-rescue LoadError
-  puts "Install the `tty` gem please"
-  exit 1
+require "bundler/cli"
+require "terminal-table"
+
+class NativeGems
+  def initialize(_options)
+  end
+
+  def run
+    groups = definition.groups
+    resolved_specs = definition.specs_for(groups).to_a
+    native_specs = resolved_specs.select { |spec| spec.extensions.any? }
+
+    output = if $stdout.tty?
+      rows = [["Name", "Version"]]
+      output = Terminal::Table.new do |t|
+        t << ["Name", "Version"]
+        t << :separator
+        native_specs.each do |spec|
+          t << [spec.name, spec.version]
+        end
+      end
+    else
+      native_specs.map { |spec| "#{spec.name}\t#{spec.version}" }
+    end
+
+    $stdout.puts output
+  end
+
+  def definition
+    Bundler.definition
+  end
 end
 
-require "bundler/setup"
+class CLI < Bundler::CLI
+  desc "native_gems [OPTIONS]", "Lists the gems with native extensions"
+  def native_gems
+    NativeGems.new(options).run
+  end
+end
 
-native_specs = Bundler.definition.resolve.to_a.select { |spec| spec.__materialize__.extensions.any? }
-
-table = TTY::Table.new(
-  header: ["Gem Name", "Version"],
-  rows: native_specs.sort_by(&:name).map {|spec| [spec.name, spec.version] }
-)
-
-puts table.render(:ascii, padding: [0, 1, 0, 1])
+CLI.start(ARGV.dup.unshift("native_gems"), :debug => true)

--- a/exe/bundler-native-gems
+++ b/exe/bundler-native-gems
@@ -4,11 +4,16 @@ require "bundler/cli"
 require "terminal-table"
 
 class NativeGems
-  def initialize(_options)
+
+  attr_reader :with, :without
+
+  def initialize(options)
+    @with = Array(options["with"]).map(&:to_sym)
+    @without = Array(options["without"]).map(&:to_sym)
   end
 
   def run
-    groups = definition.groups
+    groups = definition.groups - without + with
     resolved_specs = definition.specs_for(groups).to_a
     native_specs = resolved_specs.select { |spec| spec.extensions.any? }
 
@@ -28,6 +33,8 @@ class NativeGems
     $stdout.puts output
   end
 
+  private
+
   def definition
     Bundler.definition
   end
@@ -35,6 +42,8 @@ end
 
 class CLI < Bundler::CLI
   desc "native_gems [OPTIONS]", "Lists the gems with native extensions"
+  method_option "without", :type => :array, :banner => "Exclude gems that are part of the specified named group."
+  method_option "with", :type => :array, :banner => "Include gems that are part of the specified named group."
   def native_gems
     NativeGems.new(options).run
   end

--- a/exe/bundler-native-gems
+++ b/exe/bundler-native-gems
@@ -41,19 +41,21 @@ class NativeGems
 end
 
 class CLI < Bundler::CLI
-  def initialize(*)
-    super
-    # Replace `help` with Thor's version, not Bundler::CLI's
-    self.class.superclass.superclass.instance_method(:help).bind(self)
-  end
-
   desc "native_gems [OPTIONS]", "Lists the gems with native extensions"
   method_option "without", :type => :array, :banner => "Exclude gems that are part of the specified named group."
   method_option "with", :type => :array, :banner => "Include gems that are part of the specified named group."
   method_option "help", :banner => "Print this help"
   def native_gems
     if options[:help]
-      help("native_gems")
+      $stderr.puts <<-HELP
+USAGE: bundler native-gems [OPTIONS]
+
+OPTIONS:
+  --with group1 [group2, etc] - include gems from these bundler groups
+  --with group1 [group2, etc] - exclude gems from these bundler groups
+  --help - You're looking at it
+
+      HELP
     else
       NativeGems.new(options).run
     end


### PR DESCRIPTION
No longer do we have to guess which native gems are actually for the development group or not.

```
bundle native-gems --without development
```

Mimics entirely the logic from `bundle install` amongst other commands that accept `--with` and `--without` flags already.

Also trims down some dependencies (uses `terminal-table` instead of `tty` gem), and switches from a homegrown script to piggybacking on Bundler's thor usage for CLI argument parsing amazingness.
